### PR TITLE
Add HATEOAS support to Post and Comment controllers

### DIFF
--- a/backend/bankendapplication/pom.xml
+++ b/backend/bankendapplication/pom.xml
@@ -54,7 +54,10 @@
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-hateoas</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/controller/CommentController.java
+++ b/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/controller/CommentController.java
@@ -1,12 +1,20 @@
 package com.paf_45.bankendapplication.controller;
 
 import com.paf_45.bankendapplication.model.Comment;
+import com.paf_45.bankendapplication.model.CommentResponse;
 import com.paf_45.bankendapplication.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.Link;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/api/comments")
@@ -17,24 +25,105 @@ public class CommentController {
 
     // Get comments by post ID
     @GetMapping("/post/{postId}")
-    public ResponseEntity<List<Comment>> getCommentsByPostId(@PathVariable String postId) {
-        return ResponseEntity.ok(commentService.getCommentsByPostId(postId));
+    public ResponseEntity<CollectionModel<CommentResponse>> getCommentsByPostId(@PathVariable String postId) {
+        List<Comment> comments = commentService.getCommentsByPostId(postId);
+        
+        List<CommentResponse> commentResponses = comments.stream()
+            .map(comment -> {
+                CommentResponse response = new CommentResponse(comment);
+                
+                // Add self link
+                Link selfLink = linkTo(methodOn(CommentController.class)
+                        .getCommentById(comment.getId())).withSelfRel();
+                response.add(selfLink);
+                
+                // Add link to parent post
+                Link postLink = linkTo(methodOn(PostController.class)
+                        .getPostById(comment.getPostId())).withRel("post");
+                response.add(postLink);
+                
+                return response;
+            })
+            .collect(Collectors.toList());
+        
+        // Create collection model with links
+        CollectionModel<CommentResponse> collectionModel = CollectionModel.of(commentResponses);
+        
+        // Add link to self (collection)
+        collectionModel.add(linkTo(methodOn(CommentController.class)
+                .getCommentsByPostId(postId)).withSelfRel());
+        
+        // Add link to the post
+        collectionModel.add(linkTo(methodOn(PostController.class)
+                .getPostById(postId)).withRel("post"));
+        
+        return ResponseEntity.ok(collectionModel);
+    }
+    
+    // Get comment by ID
+    @GetMapping("/{id}")
+    public ResponseEntity<CommentResponse> getCommentById(@PathVariable String id) {
+        Optional<Comment> comment = commentService.getCommentById(id);
+        
+        if (!comment.isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+        
+        CommentResponse response = new CommentResponse(comment.get());
+        
+        // Add self link
+        Link selfLink = linkTo(methodOn(CommentController.class)
+                .getCommentById(id)).withSelfRel();
+        response.add(selfLink);
+        
+        // Add link to parent post
+        Link postLink = linkTo(methodOn(PostController.class)
+                .getPostById(comment.get().getPostId())).withRel("post");
+        response.add(postLink);
+        
+        return ResponseEntity.ok(response);
     }
 
     // Add a new comment
     @PostMapping
-    public ResponseEntity<Comment> addComment(@RequestBody Comment comment) {
-        return ResponseEntity.status(201).body(commentService.addComment(comment));
+    public ResponseEntity<CommentResponse> addComment(@RequestBody Comment comment) {
+        Comment addedComment = commentService.addComment(comment);
+        CommentResponse response = new CommentResponse(addedComment);
+        
+        // Add self link
+        Link selfLink = linkTo(methodOn(CommentController.class)
+                .getCommentById(addedComment.getId())).withSelfRel();
+        response.add(selfLink);
+        
+        // Add link to parent post
+        Link postLink = linkTo(methodOn(PostController.class)
+                .getPostById(addedComment.getPostId())).withRel("post");
+        response.add(postLink);
+        
+        return ResponseEntity.status(201).body(response);
     }
 
     // Update a comment
     @PutMapping("/{id}")
-    public ResponseEntity<Comment> updateComment(@PathVariable String id, @RequestBody Comment updatedComment) {
+    public ResponseEntity<CommentResponse> updateComment(@PathVariable String id, @RequestBody Comment updatedComment) {
         Comment comment = commentService.updateComment(id, updatedComment);
         if (comment == null) {
             return ResponseEntity.notFound().build();
         }
-        return ResponseEntity.ok(comment);
+        
+        CommentResponse response = new CommentResponse(comment);
+        
+        // Add self link
+        Link selfLink = linkTo(methodOn(CommentController.class)
+                .getCommentById(id)).withSelfRel();
+        response.add(selfLink);
+        
+        // Add link to parent post
+        Link postLink = linkTo(methodOn(PostController.class)
+                .getPostById(comment.getPostId())).withRel("post");
+        response.add(postLink);
+        
+        return ResponseEntity.ok(response);
     }
 
     // Delete a comment

--- a/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/model/CommentResponse.java
+++ b/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/model/CommentResponse.java
@@ -1,0 +1,78 @@
+package com.paf_45.bankendapplication.model;
+
+import org.springframework.hateoas.RepresentationModel;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommentResponse extends RepresentationModel<CommentResponse> {
+    private String id;
+    private String postId;
+    private String userId;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public CommentResponse() {
+    }
+
+    public CommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.postId = comment.getPostId();
+        this.userId = comment.getUserId();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+        this.updatedAt = comment.getUpdatedAt();
+    }
+
+    // Getters and Setters
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getPostId() {
+        return postId;
+    }
+
+    public void setPostId(String postId) {
+        this.postId = postId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/model/PostResponse.java
+++ b/backend/bankendapplication/src/main/java/com/paf_45/bankendapplication/model/PostResponse.java
@@ -1,0 +1,109 @@
+package com.paf_45.bankendapplication.model;
+
+import org.springframework.hateoas.RepresentationModel;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PostResponse extends RepresentationModel<PostResponse> {
+    private String id;
+    private String userId;
+    private String title;
+    private String content;
+    private List<String> tags;
+    private List<String> mediaUrls;
+    private List<String> likes;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    // Constructors
+    public PostResponse() {
+    }
+
+    public PostResponse(Post post) {
+        this.id = post.getId();
+        this.userId = post.getUserId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.tags = post.getTags();
+        this.mediaUrls = post.getMediaUrls();
+        this.likes = post.getLikes();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+    }
+
+    // Getters and Setters
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public List<String> getMediaUrls() {
+        return mediaUrls;
+    }
+
+    public void setMediaUrls(List<String> mediaUrls) {
+        this.mediaUrls = mediaUrls;
+    }
+
+    public List<String> getLikes() {
+        return likes;
+    }
+
+    public void setLikes(List<String> likes) {
+        this.likes = likes;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}


### PR DESCRIPTION
## Description
This PR implements HATEOAS (Hypermedia as the Engine of Application State) across our API endpoints to enhance discoverability, improve API navigation, and ensure our APIs are fully RESTful. By adding hypermedia links to responses, clients can dynamically discover and navigate related resources without prior knowledge of the API structure.

## Changes Made

- Added Spring HATEOAS dependency to the project
- Created response models extending RepresentationModel for:
- PostResponse
- CommentResponse
- LearningProgressUpdateResponse
- LearningPlanResponse
- Updated controllers to include hypermedia links:
- PostController - added self, posts, and comments links
- CommentController - added self and post links
- Each response now includes a _links object containing navigational links



## Checklist
- [x] Code is properly formatted and follows coding standards.
- [ ] All tests have been run and passed successfully.
- [ ] Documentation has been updated (if applicable).